### PR TITLE
Return correctly formatted datetime timezone

### DIFF
--- a/src/Schema/Scalars/DateTimeTz.php
+++ b/src/Schema/Scalars/DateTimeTz.php
@@ -4,7 +4,6 @@ namespace DeInternetJongens\LighthouseUtils\Schema\Scalars;
 
 use Carbon\Carbon;
 use GraphQL\Error\Error;
-use GraphQL\Language\AST\Node;
 use GraphQL\Language\AST\StringValueNode;
 use GraphQL\Type\Definition\ScalarType;
 use GraphQL\Utils\Utils;
@@ -25,7 +24,13 @@ class DateTimeTz extends ScalarType
      */
     public function serialize($value)
     {
-        return $value->format(self::FORMAT);
+        $value->format(self::FORMAT);
+
+        $timeZoneInHours = (float)substr($value->getTimezone()->getName(), 0, 3);
+
+        $value->addHours($timeZoneInHours);
+
+        return $value->format('Y-m-d H:i:s');
     }
 
     /**

--- a/tests/Unit/Schema/Scalars/DateTimeTzTest.php
+++ b/tests/Unit/Schema/Scalars/DateTimeTzTest.php
@@ -13,7 +13,9 @@ use SebastianBergmann\RecursionContext\InvalidArgumentException;
 
 class DateTimeTzTest extends TestCase
 {
-    const FORMAT = 'Y-m-d H:i:sP';
+    const TIMEZONE_FORMAT = 'Y-m-d H:i:sP';
+
+    const FORMAT = 'Y-m-d H:i:s';
 
     /**
      * @return array
@@ -53,16 +55,13 @@ class DateTimeTzTest extends TestCase
         }
 
         $result = $dateScalar->parseValue($input);
-        $expectedResult = Carbon::createFromFormat(self::FORMAT, $input);
+        $expectedResult = Carbon::createFromFormat(self::TIMEZONE_FORMAT, $input);
 
         $this->assertEquals($result, $expectedResult);
     }
 
     /**
-     * @return void
-     * @throws ExpectationFailedException
-     * @throws InvalidArgumentException
-     * @throws \InvalidArgumentException
+     * @throws Error
      */
     public function testSerialize(): void
     {
@@ -128,7 +127,7 @@ class DateTimeTzTest extends TestCase
             )
         );
 
-        $expectedResult = Carbon::createFromFormat(self::FORMAT, $input);
+        $expectedResult = Carbon::createFromFormat(self::TIMEZONE_FORMAT, $input);
 
         $this->assertEquals($result, $expectedResult);
     }

--- a/tests/Unit/Schema/Scalars/DateTimeTzTest.php
+++ b/tests/Unit/Schema/Scalars/DateTimeTzTest.php
@@ -66,7 +66,7 @@ class DateTimeTzTest extends TestCase
      */
     public function testSerialize(): void
     {
-        $expectedResult = '2018-09-06 13:00:00+02:00';
+        $expectedResult = '2018-09-06 15:00:00';
 
         $input = Carbon::createFromFormat(self::FORMAT, $expectedResult);
 


### PR DESCRIPTION
Format the incoming date and retrieve the timezone. Add this to the current value and return it without the timezone.